### PR TITLE
Added a prompt option to enum filter

### DIFF
--- a/lib/datagrid/filters/enum_filter.rb
+++ b/lib/datagrid/filters/enum_filter.rb
@@ -15,9 +15,12 @@ class Datagrid::Filters::EnumFilter < Datagrid::Filters::BaseFilter
     option.respond_to?(:call) ? option.call : option
   end
 
-
   def include_blank
-    self.options.has_key?(:include_blank) ? options[:include_blank] : true
+    self.options.has_key?(:include_blank) ? options[:include_blank] : true unless self.prompt
+  end
+  
+  def prompt
+    self.options.has_key?(:prompt) ? options[:prompt] : false
   end
 
   def strict

--- a/lib/datagrid/form_builder.rb
+++ b/lib/datagrid/form_builder.rb
@@ -39,7 +39,7 @@ module Datagrid
       if !options.has_key?(:multiple) && filter.multiple
         options[:multiple] = true
       end
-      select filter.name, filter.select || [], {:include_blank => filter.include_blank}, options
+      select filter.name, filter.select || [], {:include_blank => filter.include_blank, :prompt => filter.prompt}, options
     end
 
     def datagrid_integer_filter(attribute_or_filter, options = {})

--- a/spec/datagrid/form_builder_spec.rb
+++ b/spec/datagrid/form_builder_spec.rb
@@ -50,6 +50,22 @@ describe Datagrid::FormBuilder do
        <option value="second">second</option></select>'
         )}
       end
+      context "with include_blank option set to false" do
+        let(:_filter) { :category_without_include_blank }
+        it { should equal_to_dom(
+          '<select class="category_without_include_blank enum_filter" id="report_category_without_include_blank" name="report[category_without_include_blank]">
+         <option value="first">first</option>
+         <option value="second">second</option></select>'
+        )}
+      end
+      context "with prompt option" do
+        let(:_filter) { :category_with_prompt }
+        it { should equal_to_dom(
+          '<select class="category_with_prompt enum_filter" id="report_category_with_prompt" name="report[category_with_prompt]"><option value="">My Prompt</option>
+         <option value="first">first</option>
+         <option value="second">second</option></select>'
+        )}
+      end
     end
 
     context "with eboolean filter type" do

--- a/spec/support/simple_report.rb
+++ b/spec/support/simple_report.rb
@@ -21,6 +21,8 @@ class SimpleReport
 
   filter(:group_id, :integer, :multiple => true)
   filter(:category, :enum, :select => ["first", "second"])
+  filter(:category_without_include_blank, :enum, :select => ["first", "second"], :include_blank => false)
+  filter(:category_with_prompt, :enum, :select => ["first", "second"], :prompt => "My Prompt")
   filter(:disabled, :eboolean)
   filter(:confirmed, :boolean)
 


### PR DESCRIPTION
Adding the possibility of having a prompt option on the enum filter to make it more user friendly when we want to skip a filter. For example, on a report where we can filter the users, if we want to create a report where all the users are included, I could have a prompt that says "All" instead of just having a blank select option.
