### PR TITLE
Fix localization scope for filters

### DIFF
--- a/lib/datagrid/filters/base_filter.rb
+++ b/lib/datagrid/filters/base_filter.rb
@@ -37,7 +37,7 @@ class Datagrid::Filters::BaseFilter
 
   def header
     options[:header] || 
-      I18n.translate(self.name, :scope => "reports.#{grid.param_name}.filters", :default => self.name.to_s.humanize)
+      I18n.translate(self.name, :scope => "datagrid.#{grid.param_name}.filters", :default => self.name.to_s.humanize)
   end
 
   def default


### PR DESCRIPTION
Column#header and Filter#header now use the same I18n scope: 

`datagrid.#{grid.param_name}.filters` for Filters, and
`datagrid.#{grid.param_name}.columns` for Columns

instead of

`datagrid.#{grid.param_name}.filters` for Filters, and
`reports.#{grid.param_name}.columns` for Columns
