### PR TITLE
Make tests pass in 1.8.7

### DIFF
--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -62,7 +62,8 @@ class CssPattern
   end
 
   def matches?(text)
-    text = text.clone.force_encoding("UTF-8")
+    text = text.clone.force_encoding("UTF-8") if "1.9.3".respond_to? :force_encoding
+
     @matcher = Nokogiri::HTML::DocumentFragment.parse(text)
     @css_pattern.each do |css, amount_or_pattern_or_string_or_proc|
       path = @matcher.css(css)


### PR DESCRIPTION
Hey bogdan,

thank you for the final merging of my last pull request.

I pulled your newest commits into my fork to take a look at your fresh changes.
But my tests stopped working under Ruby 1.8.7.

Problem was the force_encoding method, since it's 1.9.3 specific.

I made it conditional the same way it's made in parts of the rails source.
That seems to be a common pattern for applications that run under both rubies.

Sincerely
Jakob
