### PR TITLE
Using human_attribute_name in column "header" method instead of I18n::translate

### DIFF
--- a/lib/datagrid/columns/column.rb
+++ b/lib/datagrid/columns/column.rb
@@ -36,7 +36,7 @@ class Datagrid::Columns::Column
 
   def header
     self.options[:header] || 
-      I18n.translate(self.name, :scope => "datagrid.#{self.grid.param_name}.columns", :default => self.name.to_s.humanize )
+      self.grid.scope.klass.human_attribute_name(self.name)
   end
 
   def order


### PR DESCRIPTION
It`s better to use the existing translations of the attributes, rather than create yet another translation for the datagrid
