### PR TITLE
Remove white spaces from data table row. 

### DIFF
--- a/app/views/datagrid/_row.html.erb
+++ b/app/views/datagrid/_row.html.erb
@@ -1,7 +1,5 @@
 <tr class="<%= options[:cycle] && cycle(*options[:cycle]) %>">
   <% grid.columns.each do |column| %>
-    <td class="<%= datagrid_column_classes(grid, column) %>">
-      <%= datagrid_format_value(grid, column, asset) %>
-    </td>
+    <td class="<%= datagrid_column_classes(grid, column) %>"><%= datagrid_format_value(grid, column, asset) %></td>
   <% end %>
 </tr>


### PR DESCRIPTION
Hi Bogdan,

Thanks for Datagrid, I'm using it along with Ruport and probably will migrate my reports to use Datagrid.

In one of my reports I need to wrap text inside TD in a span, for better performance I tired to only wrap TDs which are not empty. But due to white space in data row partial, Jquery wasn't return the expected result.

Hope this change will help others also. 
