### PR TITLE
Fix for undefined methods included in ActionView

### DIFF
--- a/lib/datagrid.rb
+++ b/lib/datagrid.rb
@@ -9,7 +9,11 @@ module Datagrid
   autoload :Ordering
 
   autoload :Helper
+  ActionView::Base.send(:include, Datagrid::Helper)
+  
   autoload :FormBuilder
+  ActionView::Helpers::FormBuilder.send(:include, Datagrid::FormBuilder)
+  
   autoload :Renderer
 
   autoload :Engine

--- a/lib/datagrid/form_builder.rb
+++ b/lib/datagrid/form_builder.rb
@@ -80,5 +80,4 @@ module Datagrid
   end
 end
 
-ActionView::Helpers::FormBuilder.send(:include, Datagrid::FormBuilder)
 

--- a/lib/datagrid/helper.rb
+++ b/lib/datagrid/helper.rb
@@ -36,4 +36,4 @@ module Datagrid
     end
   end
 end
-ActionView::Base.send(:include, Datagrid::Helper)
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require "active_record"
+require 'action_view'
 require "mongoid"
 require "mongo_mapper"
 require 'datagrid'


### PR DESCRIPTION
I began to get undefined methods for the view helpers after the change to using Autoload here: https://github.com/bogdan/datagrid/commit/b8929e7e23f4d35f79a1148e93dc0e88c2197874

The includes were not happening unless the constant was referenced directly, so I moved them into the main lib file.
