### PR TITLE
Add a table name to composite filter

### DIFF
--- a/lib/datagrid/drivers/active_record.rb
+++ b/lib/datagrid/drivers/active_record.rb
@@ -33,12 +33,12 @@ module Datagrid
         scope.column_names.include?(column_name.to_s) ? [scope.table_name, column_name].join(".") : nil
       end
 
-      def greater_equal(scope, field, value)
-        scope.where(["#{field} >= ?", value])
+      def greater_equal(scope, table, field, value)
+        scope.where(["#{table}.#{field} >= ?", value])
       end
 
-      def less_equal(scope, field, value)
-        scope.where(["#{field} <= ?", value])
+      def less_equal(scope, table, field, value)
+        scope.where(["#{table}.#{field} <= ?", value])
       end
     end
   end

--- a/lib/datagrid/filters/composite_filters.rb
+++ b/lib/datagrid/filters/composite_filters.rb
@@ -12,26 +12,26 @@ module Datagrid
 
       module ClassMethods
 
-        def date_range_filters(field, from_options = {}, to_options = {})
+        def date_range_filters(table, field, from_options = {}, to_options = {})
           from_options = normalize_composite_filter_options(from_options, field)
           to_options = normalize_composite_filter_options(to_options, field)
 
           filter(from_options[:name] || :"from_#{field}", :date, from_options) do |date, grid|
-            grid.driver.greater_equal(self, field, date)
+            grid.driver.greater_equal(self, table, field, date)
           end
           filter(to_options[:name] || :"to_#{field}", :date, to_options) do |date, grid|
-            grid.driver.less_equal(self, field, date)
+            grid.driver.less_equal(self, table, field, date)
           end
         end
 
-        def integer_range_filters(field, from_options = {}, to_options = {})
+        def integer_range_filters(table, field, from_options = {}, to_options = {})
           from_options = normalize_composite_filter_options(from_options, field)
           to_options = normalize_composite_filter_options(to_options, field)
           filter(from_options[:name] || :"from_#{field}", :integer, from_options) do |value, grid|
-            grid.driver.greater_equal(self, field, value)
+            grid.driver.greater_equal(self, table, field, value)
           end
           filter(to_options[:name] || :"to_#{field}", :integer, to_options) do |value, grid|
-            grid.driver.less_equal(self, field, value)
+            grid.driver.less_equal(self, table, field, value)
           end
         end
 


### PR DESCRIPTION
When using nested tables, if using similar filed names, filter will crach. 
