### PR TITLE
Updated to work with mongoid version 3

### DIFF
--- a/lib/datagrid/drivers/mongoid.rb
+++ b/lib/datagrid/drivers/mongoid.rb
@@ -12,7 +12,7 @@ module Datagrid
       end
 
       def to_scope(scope)
-        scope.where
+        scope.where(nil)
       end
 
       def where(scope, condition)


### PR DESCRIPTION
The scope.where method needs an argument, so I passed in nil.
