### PR TITLE
Allow HTML class to be specified for each column in the report.

### DIFF
--- a/lib/datagrid/helper.rb
+++ b/lib/datagrid/helper.rb
@@ -31,8 +31,8 @@ module Datagrid
     end
 
     def datagrid_column_classes(grid, column)
-        order_class = grid.order == column.name ? ["ordered", grid.descending ? "desc" : "asc"] : nil
-      [column.name, order_class].compact.join(" ")
+      order_class = grid.order == column.name ? ["ordered", grid.descending ? "desc" : "asc"] : nil
+      [column.name, order_class, column.options[:class]].compact.join(" ")
     end
   end
 end

--- a/spec/datagrid/helper_spec.rb
+++ b/spec/datagrid/helper_spec.rb
@@ -176,6 +176,17 @@ describe Datagrid::Helper do
         )
       end
 
+      it "should allow CSS classes to be specified for a column" do
+        rp = test_report do
+          scope { Entry }
+          column(:name, :class => 'my_class')
+        end
+
+        subject.datagrid_rows(rp, [entry]).should match_css_pattern(
+          "tr td.name.my_class" => "Star"
+        )
+      end
+
     end
 
     describe ".datagrid_order_for" do


### PR DESCRIPTION
We're bad and occasionally use non-semantic CSS classes. Eg, I've used this patch to specify `:class => 'nowrap'` on many of the report columns.

I couldn't find a spec for `datagrid_column_classes`. If there is one, and I've missed it, let me know and I'll write a test.

Also as you use a wiki rather than putting the documentation in the source I have not included a documentation update.
