### PR TITLE
Allow raw html in "sort" header column

### DIFF
--- a/lib/datagrid/renderer.rb
+++ b/lib/datagrid/renderer.rb
@@ -74,11 +74,11 @@ module Datagrid
     def order_for(grid, column)
       @template.content_tag(:div, :class => "order") do
         @template.link_to(
-          I18n.t("datagrid.table.order.asc", :default => "&uarr;".html_safe),
+          I18n.t("datagrid.table.order.asc", :default => "&uarr;".html_safe).html_safe,
           @template.url_for(grid.param_name => grid.attributes.merge(:order => column.name, :descending => false)),
           :class => "order asc"
         ) + " " + @template.link_to(
-          I18n.t("datagrid.table.order.desc", :default => "&darr;".html_safe),
+          I18n.t("datagrid.table.order.desc", :default => "&darr;".html_safe).html_safe,
           @template.url_for(grid.param_name => grid.attributes.merge(:order => column.name, :descending => true )),
           :class => "order desc"
         )


### PR DESCRIPTION
My goal was to display a sort icon on tables instead or the character arrow (&uarr;)
