### PR TITLE
Update filters.rb

### DIFF
--- a/lib/datagrid/filters.rb
+++ b/lib/datagrid/filters.rb
@@ -84,7 +84,8 @@ module Datagrid
       def assets
         result = super
         self.class.filters.each do |filter|
-          result = filter.apply(self, result, filter_value(filter))
+          result_filter = filter.apply(self, result, filter_value(filter))
+          result = result_filter if result_filter
         end
         result
       end


### PR DESCRIPTION
Only apply the filter onto the result if it's valid, a badly coded filter block could return anything which would reset result. Eg:

```
filter(:field) do
    nil
end
```

It may even be worthwhile checking if filter_result is a ActiveRecord::Relation?
