### PR TITLE
Fix calls to order_unsupported.

### DIFF
--- a/lib/datagrid/drivers/active_record.rb
+++ b/lib/datagrid/drivers/active_record.rb
@@ -40,6 +40,11 @@ module Datagrid
         scope.reorder(order).reverse_order
       end
 
+      # TODO: implement reverse_order
+      # def reverse_order(scope)
+      #   scope.reverse_order
+      # end
+
       def default_order(scope, column_name)
         has_column?(scope, column_name) ? [scope.table_name, column_name].join(".") : nil
       end

--- a/lib/datagrid/ordering.rb
+++ b/lib/datagrid/ordering.rb
@@ -18,9 +18,7 @@ module Datagrid
               order_unsupported(value, "no column #{value} in #{self.class}")
             end
             unless column.order
-              order_unsupported(
-                name, "#{self.class}##{name} don't support order" 
-              ) 
+              order_unsupported(name, "#{self.class}##{name} don't support order" ) 
             end
             value
           else
@@ -90,7 +88,7 @@ module Datagrid
       def reverse_order(assets)
         driver.reverse_order(assets)
       rescue NotImplementedError
-        self.class.order_unsupported("Your ORM do not support reverse order: please specify :order_desc option manually")
+        self.class.order_unsupported("Reverse", "Your ORM do not support reverse order: please specify :order_desc option manually")
       end
 
       def apply_block_order(assets, order)
@@ -100,7 +98,7 @@ module Datagrid
         when 1
           order.call(assets)
         else
-          self.class.order_unsupported("Order option proc can not handle more than one argument")
+          self.class.order_unsupported("Proc", "Order option proc can not handle more than one argument")
         end
       end
     end # InstanceMethods


### PR DESCRIPTION
Hey Bogdan, I ran into some issues while trying to provide a custom ordering for a column.  It turns out the rails reverse_order method on relations is broken if the you call it on an ordering that uses SQL functions or certain features of postgres (https://github.com/rails/rails/pull/8741, https://github.com/rails/rails/pull/8225, https://github.com/rails/rails/pull/2234, etc).  For example if you did:

``` Ruby
column "Fake Column", order: "COALESE(A, B)"
```

It would generate the SQL "SELECT... ORDER BY  COALESE(A DESC, B);", instead of "SELECT... ORDER BY COALESE(A, B) DESC". This is Rails' fault, but it might be worth documenting.   

I eventually got around this by manually specifying order_desc: "COALESE(A,B) DESC", but before I came up with that solution, I was looking at using a proc and I ran into strange errors because driver.reverse_order isn't implemented for active_record.  I think it probably should be, but I'm not sure exactly what it should look like.  I also found that you were missing the "name" argument to a few order_unsupported calls.  I'm not sure what exactly the names should be, but you can see my fix in this pull request.  I also noticed that it's an option to have this proc take the relation as an argument, but it appears to be undocumented/tested.  

Let me know if any of this doesn't make sense and I can try to explain it better.  
