### PR TITLE
Add html_attributes column option

### DIFF
--- a/app/views/datagrid/_row.html.erb
+++ b/app/views/datagrid/_row.html.erb
@@ -1,6 +1,6 @@
 <tr class="<%= options[:cycle] && cycle(*options[:cycle]) %>">
   <% grid.html_columns(*options[:columns]).each do |column| %>
-    <%= datagrid_td_tag(grid, column) do %>
+    <%= datagrid_td_tag(grid, column, asset) do %>
       <%= datagrid_format_value(grid, column, asset) %>
     <% end %>
   <% end %>

--- a/lib/datagrid/helper.rb
+++ b/lib/datagrid/helper.rb
@@ -17,9 +17,18 @@ module Datagrid
       datagrid_renderer.format_value(grid, column_name, model)
     end
 
-    def datagrid_td_tag grid, column, &block
-      content = block_given? ? capture(&block) : ''
-      "<td class=\"#{datagrid_column_classes(grid, column)}\">#{content}</td>".html_safe
+    def datagrid_td_tag grid, column, model, &block
+      td_options = { :class => datagrid_column_classes(grid, column) }
+      if column.options[:html_attributes]
+        html_attributes = if column.options[:html_attributes].is_a? Proc
+          column.options[:html_attributes].call(model)
+        else
+          column.options[:html_attributes]
+        end
+
+        td_options.merge!(html_attributes)
+      end
+      content_tag :td, td_options, &block
     end
 
     def datagrid_format_value(grid, column_name, model) #:nodoc:

--- a/spec/datagrid/helper_spec.rb
+++ b/spec/datagrid/helper_spec.rb
@@ -128,6 +128,38 @@ describe Datagrid::Helper do
       end
     end
 
+    context "with html_attributes as a Hash" do
+      let(:grid) do
+        test_report do
+          scope { Entry }
+          column(:name, :html_attributes => {:rowspan => 2})
+        end
+      end
+
+      it "should output only given column names" do
+        subject.datagrid_table(grid, [entry]).should match_css_pattern(
+          "table.datagrid th.name" => 1,
+          "table.datagrid td.name[rowspan='2']" => 1
+        )
+      end
+    end
+
+    context "with html_attributes as a Proc" do
+      let(:grid) do
+        test_report do
+          scope { Entry }
+          column(:name, :html_attributes => lambda {|m| { "data-name" => m.name } })
+        end
+      end
+
+      it "should output only given column names" do
+        subject.datagrid_table(grid, [entry]).should match_css_pattern(
+          "table.datagrid th.name" => 1,
+          "table.datagrid td.name[data-name='Star']" => 1
+        )
+      end
+    end
+
     context 'with partials attribute' do
       let(:grid) do
         test_report do

--- a/spec/support/test_partials/client/datagrid/_row.html.erb
+++ b/spec/support/test_partials/client/datagrid/_row.html.erb
@@ -1,7 +1,7 @@
 <tr class="<%= options[:cycle] && cycle(*options[:cycle]) %>">
   <p>Namespaced row partial.</p>
   <% grid.html_columns(*options[:columns]).each do |column| %>
-    <%= datagrid_td_tag(grid, column) do %>
+    <%= datagrid_td_tag(grid, column, asset) do %>
       <%= datagrid_value(grid, column, asset) %>
     <% end %>
   <% end %>


### PR DESCRIPTION
As suggested in #43.

Our use case is that we need to be able to specify a rowspan for some form columns.
