### PR TITLE
Tiny performance improve

### DIFF
--- a/lib/datagrid/columns.rb
+++ b/lib/datagrid/columns.rb
@@ -324,7 +324,7 @@ module Datagrid
       def to_csv(*column_names)
         options = column_names.extract_options!
         csv_class.generate(
-          {:headers => self.header(*column_names), :write_headers => true}.merge(options)
+          {:headers => self.header(*column_names), :write_headers => true}.merge!(options)
         ) do |csv|
           each_with_batches do |asset|
             csv << row_for(asset, *column_names)


### PR DESCRIPTION
in this case we can use bang method

``` ruby
require 'benchmark/ips'
Benchmark.ips do |x|
  def test1
    {:headers => 'test', write_headers: true}.merge(:col_sep => ';')
  end

  def test2
    {:headers => 'test', write_headers: true}.merge!(:col_sep => ';')
  end

  x.report('test1') { test1 }
  x.report('test2') { test2 }

  x.compare!
end
```

````
Calculating -------------------------------------
               test1    53.437k i/100ms
               test2    75.371k i/100ms
-------------------------------------------------
               test1    810.729k (± 2.3%) i/s -      4.061M
               test2      1.466M (± 2.9%) i/s -      7.386M

Comparison:
               test2:  1465705.3 i/s
               test1:   810728.8 i/s - 1.81x slower