### PR TITLE
[WIP] Implementing Sequel ORM support

### DIFF
--- a/lib/datagrid/drivers.rb
+++ b/lib/datagrid/drivers.rb
@@ -3,6 +3,7 @@ require "datagrid/drivers/active_record"
 require "datagrid/drivers/array"
 require "datagrid/drivers/mongoid"
 require "datagrid/drivers/mongo_mapper"
+require "datagrid/drivers/sequel"
 
 
 module Datagrid

--- a/lib/datagrid/drivers/sequel.rb
+++ b/lib/datagrid/drivers/sequel.rb
@@ -1,0 +1,32 @@
+module Datagrid
+  module Drivers
+    class Sequel < AbstractDriver #:nodoc:
+
+      def self.match?(scope)
+        return false unless defined?(::Sequel)
+        if scope.is_a?(Class)
+          scope.ancestors.include?(::Sequel::Model)
+        else
+          scope.is_a?(::Sequel::Dataset)
+        end
+      end
+
+      def to_scope(scope)
+        return scope if scope.is_a?(::Sequel::Dataset)
+        scope.naked
+      end
+
+      def asc(scope, order)
+        scope.order_append(order)
+      end
+
+      def desc(scope, order)
+        scope.order_append(::Sequel.desc(order))
+      end
+
+      def default_order(scope, column_name)
+        nil # has_column?(scope, column_name) ? [scope.table_name, column_name].join(".") : nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello @bogdan. This is the __beginning__ of Sequel support. I have not run the tests against the Sequel code yet, and I only implemented the minimum amount of code possible to get Datagrid running for one screen I have.

`AbstractDriver` has no documentation. For me, this makes it difficult to fully implement the Sequel driver, since I don't know exactly what the methods are supposed to be doing.

What does the `#default_order` method do? It seems to be the default order for the column, but I'm not sure. Returning nil seemed like a safe option.