### PR TITLE
Allow column to accept and perform desc reorder on Arel

### DIFF
--- a/lib/datagrid/drivers/active_record.rb
+++ b/lib/datagrid/drivers/active_record.rb
@@ -48,7 +48,11 @@ module Datagrid
       end
 
       def desc(scope, order)
-        scope.reorder(order).reverse_order
+        if order.respond_to?(:desc)
+          scope.reorder(order.desc)
+        else
+          scope.reorder(order).reverse_order
+        end
       end
 
       def reverse_order(scope)

--- a/spec/datagrid/drivers/active_record_spec.rb
+++ b/spec/datagrid/drivers/active_record_spec.rb
@@ -21,6 +21,18 @@ describe Datagrid::Drivers::ActiveRecord do
     expect(scope.to_sql.strip).to eq('SELECT "entries".*, sum(entries.group_id) AS sum_group_id FROM "entries"')
   end
 
+  describe "Arel" do
+    subject do
+      test_report(:order => :test, :descending => true) do
+        scope { Entry }
+        column(:test, order: Arel::Nodes::Count.new(["entries.group_id"]))
+      end.assets
+    end
+
+    it "should support ordering by Arel columns" do
+      expect(subject.to_sql.strip).to include "ORDER BY COUNT('entries.group_id') DESC"
+    end
+  end
 
   describe "gotcha #datagrid_where_by_timestamp" do
 


### PR DESCRIPTION
Add simple functionality to fix descending ActiveRecord functionality allowing Arel within order parameter.