### PR TITLE
Added raw_csv_headers config option

### DIFF
--- a/lib/datagrid/columns.rb
+++ b/lib/datagrid/columns.rb
@@ -272,6 +272,15 @@ module Datagrid
         data_columns(*column_names).map(&:header)
       end
 
+      # Returns <tt>Array</tt> of raw column names.
+      #
+      # Arguments:
+      #
+      #   * <tt>column_names</tt> - list of column names if you want to limit data only to specified columns
+      def data_column_names(*column_names)
+        data_columns(*column_names).map(&:name)
+      end
+
       # Returns <tt>Array</tt> column values for given asset
       #
       # Arguments:
@@ -347,8 +356,15 @@ module Datagrid
       #   grid.to_csv(:col_sep => ';')
       def to_csv(*column_names)
         options = column_names.extract_options!
+
+        headers = if Datagrid.configuration.raw_csv_headers
+          self.data_column_names(*column_names)
+        else
+          self.header(*column_names)
+        end
+
         csv_class.generate(
-          {:headers => self.header(*column_names), :write_headers => true}.merge!(options)
+          {:headers => headers, :write_headers => true}.merge!(options)
         ) do |csv|
           each_with_batches do |asset|
             csv << row_for(asset, *column_names)

--- a/lib/datagrid/configuration.rb
+++ b/lib/datagrid/configuration.rb
@@ -8,6 +8,6 @@ module Datagrid
     yield(configuration)
   end
 
-  class Configuration < Struct.new(:date_formats, :datetime_formats)
+  class Configuration < Struct.new(:date_formats, :datetime_formats, :raw_csv_headers)
   end
 end

--- a/spec/datagrid/columns_spec.rb
+++ b/spec/datagrid/columns_spec.rb
@@ -149,6 +149,17 @@ describe Datagrid::Columns do
       expect(subject.to_csv(:col_sep => ";")).to eq("Shipping date;Group;Name;Access level;Pet\n#{date};Pop;Star;admin;ROTTWEILER\n")
     end
 
+    context "with raw_csv_headers true" do
+      around(:each) do |example|
+        with_raw_csv_headers do
+          example.run
+        end
+      end
+
+      it "should use raw headers" do
+        expect(subject.to_csv.split("\n")[0]).to eq("shipping_date,group,name,access_level,pet")
+      end
+    end
   end
 
   it "should support columns with model and report arguments" do

--- a/spec/support/configuration.rb
+++ b/spec/support/configuration.rb
@@ -26,3 +26,16 @@ def with_datetime_format(format = "%m/%d/%Y")
   end
 end
 
+def with_raw_csv_headers
+  begin
+    old_value = Datagrid.configuration.raw_csv_headers
+    Datagrid.configure do |config|
+      config.raw_csv_headers = true
+    end
+    yield
+  ensure
+    Datagrid.configure do |config|
+      config.raw_csv_headers = old_value
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a `raw_csv_headers` config option that when set to true, uses the raw column names instead of the translated ones. These seem better suited to CSV in some cases where the data are being input to a statistical program, etc.