### PR TITLE
Show HTML symbols for header

### DIFF
--- a/lib/datagrid/columns/column.rb
+++ b/lib/datagrid/columns/column.rb
@@ -158,7 +158,7 @@ class Datagrid::Columns::Column
   end
 
   def callable(value)
-    value.respond_to?(:call) ? value.call : value
+    value.respond_to?(:call) ? value.call : value.html_safe
   end
 
   def driver


### PR DESCRIPTION
```ruby
column(:test, header: "test <br> &pound; &copy; &reg;")
```

before:
![](https://monosnap.com/file/zO1OW3IJIUwrdtTxCHNu2wVoGCNb0z.png)


after:
![](https://monosnap.com/file/mxvUsS3vXRP5EJw2JuMupa4UkBkWkg.png)