### PR TITLE
Avoid calling filters instance method prematurely

### DIFF
--- a/lib/datagrid/filters.rb
+++ b/lib/datagrid/filters.rb
@@ -49,8 +49,6 @@ module Datagrid
 
     module ClassMethods
 
-      alias_attribute :filters, :filters_array
-
       # Returns filter definition object by name
       def filter_by_name(attribute)
         return attribute if attribute.is_a?(Datagrid::Filters::BaseFilter)
@@ -118,6 +116,10 @@ module Datagrid
         "#{super}(#{filters_inspection})"
       end
 
+      def filters
+        filters_array
+      end
+
       protected
 
       def inherited(child_class)
@@ -134,8 +136,6 @@ module Datagrid
     end # ClassMethods
 
     module InstanceMethods
-
-      delegate :filter_by_name, :default_filter, to: :class
 
       def initialize(*args, &block) # :nodoc:
         self.filters_array = self.class.filters_array.clone
@@ -165,6 +165,11 @@ module Datagrid
         end
       end
 
+      # Returns filter object with the given name
+      def filter_by_name(name)
+        self.class.filter_by_name(name)
+      end
+
       # Returns assets filtered only by specified filters
       # Allows partial filtering
       def filter_by(*filters)
@@ -179,6 +184,10 @@ module Datagrid
           raise ::Datagrid::ArgumentError, "#{filter.name} with type #{FILTER_TYPES.invert[filter.class].inspect} can not have select options"
         end
         filter.select(self)
+      end
+
+      def default_filter
+        self.class.default_filter
       end
 
       # Returns all currently enabled filters

--- a/lib/datagrid/filters.rb
+++ b/lib/datagrid/filters.rb
@@ -139,7 +139,7 @@ module Datagrid
 
       def initialize(*args, &block) # :nodoc:
         self.filters_array = self.class.filters_array.clone
-        filters.each do |filter|
+        self.filters_array.each do |filter|
           self[filter.name] = filter.default(self)
         end
         super(*args, &block)

--- a/lib/datagrid/filters.rb
+++ b/lib/datagrid/filters.rb
@@ -49,6 +49,8 @@ module Datagrid
 
     module ClassMethods
 
+      alias_attribute :filters, :filters_array
+
       # Returns filter definition object by name
       def filter_by_name(attribute)
         return attribute if attribute.is_a?(Datagrid::Filters::BaseFilter)
@@ -116,10 +118,6 @@ module Datagrid
         "#{super}(#{filters_inspection})"
       end
 
-      def filters
-        filters_array
-      end
-
       protected
 
       def inherited(child_class)
@@ -136,6 +134,8 @@ module Datagrid
     end # ClassMethods
 
     module InstanceMethods
+
+      delegate :filter_by_name, :default_filter, to: :class
 
       def initialize(*args, &block) # :nodoc:
         self.filters_array = self.class.filters_array.clone
@@ -165,11 +165,6 @@ module Datagrid
         end
       end
 
-      # Returns filter object with the given name
-      def filter_by_name(name)
-        self.class.filter_by_name(name)
-      end
-
       # Returns assets filtered only by specified filters
       # Allows partial filtering
       def filter_by(*filters)
@@ -184,10 +179,6 @@ module Datagrid
           raise ::Datagrid::ArgumentError, "#{filter.name} with type #{FILTER_TYPES.invert[filter.class].inspect} can not have select options"
         end
         filter.select(self)
-      end
-
-      def default_filter
-        self.class.default_filter
       end
 
       # Returns all currently enabled filters

--- a/spec/datagrid/filters_spec.rb
+++ b/spec/datagrid/filters_spec.rb
@@ -292,5 +292,33 @@ describe Datagrid::Filters do
       expect(non_admin_filters).to_not include(:id)
       expect(non_admin_filters).to include(:name)
     end
+
+    context 'with delegation to attribute' do
+      let(:role) { OpenStruct.new('admin?' => admin) }
+      let(:klass) do
+        test_report_class do
+          attr_accessor :role
+          delegate :admin?, to: :role
+
+          scope { Entry }
+
+          filter(:id, :integer, if: :admin?)
+        end
+      end
+
+      subject { klass.new(role: role).filters.map(&:name) }
+
+      context 'when condition is true' do
+        let(:admin) { true }
+
+        it { is_expected.to include(:id) }
+      end
+
+      context 'when condition is false' do
+        let(:admin) { false }
+
+        it { is_expected.to_not include(:id) }
+      end
+    end
   end
 end


### PR DESCRIPTION
I propose this change to avoid calling an instance method on a not completely initialized object. More precisely to fix the case when an _if_ or _unless_ condition references an attribute that hasn't been set yet.

```ruby
module RoleDependant
  extend ActiveSupport::Concern

  included do
    attr_accessor :role

    delegate :admin?, to: :role
  end
end

class FooGrid
  include Datagrid, RoleDependant
  ...
  filter(..., if: :admin?)
end

FooGrid.new(role: some_role)
```

This gives a _NoMethodError_, because _role_ is nil, when ```enabled?``` is evaluated.