### PR TITLE
Add 'defaults' translation namespace for columns and filters

### DIFF
--- a/lib/datagrid/utils.rb
+++ b/lib/datagrid/utils.rb
@@ -14,16 +14,23 @@ module Datagrid
 
       def translate_from_namespace(namespace, grid_class, key)
         deprecated_key = :"datagrid.#{grid_class.param_name}.#{namespace}.#{key}"
-        live_key = :"datagrid.#{grid_class.model_name.i18n_key}.#{namespace}.#{key}"
         i18n_key = grid_class.model_name.i18n_key.to_s
+
+        lookups = []
+        lookups << :"datagrid.#{grid_class.model_name.i18n_key}.#{namespace}.#{key}"
+        lookups << :"datagrid.#{namespace}.defaults.#{key}"
+        lookups << key.to_s.humanize
 
         if grid_class.param_name != i18n_key && I18n.exists?(deprecated_key)
           Datagrid::Utils.warn_once(
-            "Deprecated translation namespace 'datagrid.#{grid_class.param_name}' for #{grid_class}. Use 'datagrid.#{i18n_key}' instead."
+            "Deprecated translation namespace 'datagrid.#{grid_class.param_name}'" +
+              " for #{grid_class}. Use 'datagrid.#{i18n_key}' instead."
           )
+
           return I18n.t(deprecated_key)
         end
-        I18n.t(live_key, default: key.to_s.humanize).presence
+
+        I18n.t(lookups.shift, default: lookups).presence
       end
 
       def warn_once(message, delay = 5)

--- a/spec/datagrid/columns_spec.rb
+++ b/spec/datagrid/columns_spec.rb
@@ -63,7 +63,7 @@ describe Datagrid::Columns do
           column(:name)
         end
       end
-      it "translates column with deprecated namespace" do
+      it "translates column-header with deprecated namespace" do
         silence_warnings do
           store_translations(:en, datagrid: {ns45_translated_report: {columns: {name: "Navn"}}}) do
             expect(Ns45::TranslatedReport.new.header.first).to eq("Navn")
@@ -71,22 +71,36 @@ describe Datagrid::Columns do
         end
       end
 
-      it "translates column with namespace" do
+      it "translates column-header with namespace" do
         store_translations(:en, datagrid: {:"ns45/translated_report" => {columns: {name: "Navn"}}}) do
           expect(Ns45::TranslatedReport.new.header.first).to eq("Navn")
         end
       end
 
-      it "translates column without namespace" do
+      it "translates column-header without namespace" do
         class Report27
           include Datagrid
           scope {Entry}
           column(:name)
         end
+
         store_translations(:en, datagrid: {:"report27" => {columns: {name: "Nombre"}}}) do
           expect(Report27.new.header.first).to eq("Nombre")
         end
       end
+
+      it "translates column-header in using defaults namespace" do
+        class Report27
+          include Datagrid
+          scope {Entry}
+          column(:name)
+        end
+
+        store_translations(:en, datagrid: {columns: {defaults: {name: "Nombre"}}}) do
+          expect(Report27.new.header.first).to eq("Nombre")
+        end
+      end
+
     end
 
     it "should return html_columns" do

--- a/spec/datagrid/filters_spec.rb
+++ b/spec/datagrid/filters_spec.rb
@@ -224,6 +224,13 @@ describe Datagrid::Filters do
       end
     end
 
+    it "translates filter using defaults namespace" do
+      grid = Ns46::TranslatedReport.new
+      store_translations(:en, datagrid: {filters: {defaults: {name: "Navn"}}}) do
+        expect(grid.filters.map(&:header)).to eq(["Navn"])
+      end
+    end
+
   end
 
 


### PR DESCRIPTION
When having a lot of grids in a project a lot of duplication is created when adding translations for grids that are inherited or mixed.

This will allow you to get rid of some of the duplication and make them easier to manage.