### PR TITLE
Allow non-number characters in number filters

### DIFF
--- a/lib/datagrid/filters/integer_filter.rb
+++ b/lib/datagrid/filters/integer_filter.rb
@@ -11,7 +11,7 @@ class Datagrid::Filters::IntegerFilter < Datagrid::Filters::BaseFilter
       return value.id
     end
     return value if value.is_a?(Range)
-    value.to_i
+    value.gsub(/[^\d]/, '').to_i
   end
 end
 

--- a/lib/datagrid/filters/integer_filter.rb
+++ b/lib/datagrid/filters/integer_filter.rb
@@ -11,7 +11,6 @@ class Datagrid::Filters::IntegerFilter < Datagrid::Filters::BaseFilter
       return value.id
     end
     return value if value.is_a?(Range)
-    value.gsub(/[^\d]/, '').to_i
+    value.to_s.gsub(/[^\d]/, '').to_i
   end
 end
-

--- a/spec/datagrid/filters/integer_filter_spec.rb
+++ b/spec/datagrid/filters/integer_filter_spec.rb
@@ -141,4 +141,13 @@ describe Datagrid::Filters::IntegerFilter do
 
     expect(report.group_id).to eq(group.id)
   end
+
+  it "should remove non-number characters" do
+    report = test_report(:group_id => ["$3", "$5,000"]) do
+      scope { Entry }
+      filter(:group_id, :integer, :range => true)
+    end
+    expect(report.assets).to include(entry7)
+    expect(report.assets).not_to include(entry2)
+  end
 end


### PR DESCRIPTION
I have a salary range filter in my app, and users often enter `$100,000` or `$50,000`, which doesn't work. This change removes all non-number characters from a filter value before attempting to convert it to an integer.

One possible problem is that `"3.4"` would now become `34` instead of `3`. I could easily change the regex to allow `.` if you'd prefer.