### PR TITLE
Fix warnings about `Fixnum` in tests

### DIFF
--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -70,7 +70,7 @@ class CssPattern
         if !html.match(pattern_or_string)
           return error!("#{css.inspect} did not match #{pattern_or_string.inspect}. It was \n:#{html.inspect}")
         end
-      elsif amount_or_pattern_or_string_or_proc.is_a? Fixnum
+      elsif amount_or_pattern_or_string_or_proc.is_a? Numeric
         expected_amount = amount_or_pattern_or_string_or_proc
         amount = path.size
         if amount != expected_amount


### PR DESCRIPTION
When running the tests under Ruby 2.4.0+, the following warning is printed a few times:

    spec/support/matchers.rb:73: warning: constant ::Fixnum is deprecated

`Fixnum` was deprecated in Ruby 2.4.0, but `Numeric` exists in all Ruby versions that Travis tests against.