### PR TITLE
Add filter groups

### DIFF
--- a/app/views/datagrid/_form.html.erb
+++ b/app/views/datagrid/_form.html.erb
@@ -1,8 +1,12 @@
 <%= form_for grid, options do |f| -%>
-  <% grid.filters.each do |filter| %>
-    <div class="datagrid-filter filter">
-      <%= f.datagrid_label filter %>
-      <%= f.datagrid_filter filter %>
+  <% grid.filters.group_by(&:filter_group).each do |group, filters| %>
+    <div class="datagrid-filter-group <%= group %>">
+      <% filters.each do |filter| %>
+        <div class="datagrid-filter filter">
+          <%= f.datagrid_label filter %>
+          <%= f.datagrid_filter filter %>
+        </div>
+      <% end %>
     </div>
   <% end %>
   <div class="datagrid-actions">

--- a/lib/datagrid/filters/base_filter.rb
+++ b/lib/datagrid/filters/base_filter.rb
@@ -3,13 +3,14 @@ end
 
 class Datagrid::Filters::BaseFilter #:nodoc:
 
-  attr_accessor :grid_class, :options, :block, :name
+  attr_accessor :grid_class, :options, :block, :name, :filter_group
 
   def initialize(grid_class, name, options = {}, &block)
     self.grid_class = grid_class
     self.name = name
     self.options = options
     self.block = block || default_filter_block
+    self.filter_group = options[:filter_group] || ""
   end
 
   def parse(value)

--- a/spec/datagrid/filters/base_filter_spec.rb
+++ b/spec/datagrid/filters/base_filter_spec.rb
@@ -16,4 +16,13 @@ describe Datagrid::Filters::BaseFilter do
     expect(report.assets).not_to include(Entry.create!(:name => ""))
   end
 
+  it "supports a filter_group accessor" do
+    report = test_report do
+      scope {Entry}
+      filter(:name, :string, filter_group: "my group name")
+    end
+
+    expect(report.filters.first.filter_group).to eq("my group name")
+  end
+
 end

--- a/spec/support/test_partials/client/datagrid/_form.html.erb
+++ b/spec/support/test_partials/client/datagrid/_form.html.erb
@@ -1,9 +1,13 @@
 <%= form_for grid, options do |f| -%>
   <p>Namespaced form partial.</p>
-  <% grid.filters.each do |filter| %>
-    <div class="datagrid-filter filter">
-      <%= f.datagrid_label filter %>
-      <%= f.datagrid_filter filter %>
+  <% grid.filters.group_by(&:filter_group).each do |group, filters| %>
+    <div class="datagrid-filter-group <%= group %>">
+      <% filters.each do |filter| %>
+        <div class="datagrid-filter filter">
+          <%= f.datagrid_label filter %>
+          <%= f.datagrid_filter filter %>
+        </div>
+      <% end %>
     </div>
   <% end %>
   <div class="datagrid-actions">


### PR DESCRIPTION
This PR adds a `filter_group` attribute to filters, which is set via the `options` hash

Its purpose is to allow filters to be grouped together, to enhance theming ability, as the `form` partial will add a wrapping div based on those filters.

When I added the view logic to the partial and the test partial, no tests failed, so I'm not sure where I should have added a test for this new HTML logic. Would love feedback on that, and I can add the tests as needed.