### PR TITLE
set batch_size default to 1000

### DIFF
--- a/lib/datagrid/columns.rb
+++ b/lib/datagrid/columns.rb
@@ -15,7 +15,7 @@ module Datagrid
         class_attribute :default_column_options, :instance_writer => false
         self.default_column_options = {}
 
-        class_attribute :batch_size
+        class_attribute :batch_size, default: 1000
 
         class_attribute :columns_array
         self.columns_array = []

--- a/spec/datagrid_spec.rb
+++ b/spec/datagrid_spec.rb
@@ -60,8 +60,8 @@ describe Datagrid do
 
   describe ".batch_size" do
     context "when not defined on class level" do
-      it "returns nil" do
-        expect(subject.batch_size).to eq(nil)
+      it "returns 1000" do
+        expect(subject.batch_size).to eq(1000)
       end
     end
 
@@ -77,6 +77,17 @@ describe Datagrid do
       end
     end
 
+    context "when set to nil in the grid class" do
+      subject do
+        test_report do
+          self.batch_size = nil
+        end
+      end
+
+      it "returns nil" do
+        expect(subject.batch_size).to eq(nil)
+      end
+    end
   end
 
 


### PR DESCRIPTION
Previously the documentation commented that batch_size had a default of 1000
but the implementation and specs had a default of 1000.

Resolves https://github.com/bogdan/datagrid/issues/276