### PR TITLE
Fix `column(:attr, html: true, &:symbol)`

### DIFF
--- a/lib/datagrid/columns.rb
+++ b/lib/datagrid/columns.rb
@@ -535,6 +535,8 @@ module Datagrid
       def value_from_html_block(context, asset, column)
         args = []
         remaining_arity = column.html_block.arity
+        remaining_arity = 1 if remaining_arity < 0
+
         asset = decorate(asset)
 
         if column.data?

--- a/spec/datagrid/helper_spec.rb
+++ b/spec/datagrid/helper_spec.rb
@@ -245,6 +245,17 @@ describe Datagrid::Helper do
       )
     end
 
+    it "should render columns with &:symbol block" do
+      rp = test_report do
+        scope { Entry }
+        column(:name, &:name)
+      end
+
+      expect(subject.datagrid_rows(rp, [entry])).to match_css_pattern(
+        "tr td.name" => "Star"
+      )
+    end
+
     it "should render html columns" do
       rp = test_report do
         scope { Entry }
@@ -254,6 +265,41 @@ describe Datagrid::Helper do
       end
       expect(subject.datagrid_rows(rp, [entry])).to match_css_pattern(
         "tr td.name span" => "Star"
+      )
+    end
+
+    it "should render :html columns with &:symbol block" do
+      rp = test_report do
+        scope { Entry }
+        column(:name, :html => true, &:name)
+      end
+
+      expect(subject.datagrid_rows(rp, [entry])).to match_css_pattern(
+        "tr td.name" => "Star"
+      )
+    end
+
+    it "should render format columns with &:symbol block" do
+      rp = test_report do
+        scope { Entry }
+        column(:name) do |record|
+          format(record, &:name)
+        end
+      end
+
+      expect(subject.datagrid_rows(rp, [entry])).to match_css_pattern(
+        "tr td.name" => "Star"
+      )
+    end
+
+    it "should render :html columns with &:symbol block with a data attribute" do
+      rp = test_report do
+        scope { Entry }
+        column(:name, :html => true, data: 'DATA', &:name)
+      end
+
+      expect(subject.datagrid_rows(rp, [entry])).to match_css_pattern(
+        "tr td.name" => "Star"
       )
     end
 


### PR DESCRIPTION
rubocop told me to change column(...) { |record| record.value } to
column(..., &:value) which should in most cases be equivalent. in this
case, because datagrid does magic with arity and instance_exec it was
raising instead. because the proc from Symbol#to_proc has -1 arity.

```
ActionView::Template::Error:
  no receiver given
```

I set the arity to 1 rather than passing the block e.g. data, row, grid

1. because that solves this the Symbol#to_proc case: a instance_exec
with more than one argument supplies the rest of the arguments the
symbol method.

2. because this is how non-html: true columns work currently work with
negative arity. the receiver of instance_exec is the value supplied to
the block, and no additional arguments are supplied

3. because wanting the grid and row with splat arguments just seems
unlikely
```ruby
column(:my_column, html: true) do |*args|
  # i can't think of anything here
end
```

I also added a couple of already-passing tests because there didn't seem
to be coverage of this case for non html: true columns or format values