### PR TITLE
Test against multiple Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
-    name: 'Ruby ${{ matrix.ruby-version }}'
+        rails-version:
+          - '6.0'
+          - '6.1'
+          - '7.0'
+    name: 'Ruby ${{ matrix.ruby-version }}, Rails ${{ matrix.rails-version }}'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,4 +25,6 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby-version }}'
           bundler-cache: true
+        env:
+          TEST_RAILS_VERSION: '${{ matrix.rails-version }}'
       - run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "rails", "~> #{ENV['TEST_RAILS_VERSION']}" if ENV["TEST_RAILS_VERSION"]
   gem "bump"
 
   gem "pry-byebug"


### PR DESCRIPTION
Are you sure `autocomplete="off"` is only added in Rails 7+?
I’ve added multiple Rails versions to CI build, and it seems the commit 98ae870 breaks build for Rails < 7.