### PR TITLE
Fix undefined method 'exists?' for File:Class (NoMethodError) in ruby 3.2.0

### DIFF
--- a/lib/datagrid/scaffold.rb
+++ b/lib/datagrid/scaffold.rb
@@ -124,6 +124,6 @@ RUBY
 
   def file_exists?(name)
     name = Rails.root.join(name) unless name.to_s.first == "/"
-    File.exists?(name)
+    File.exist?(name)
   end
 end


### PR DESCRIPTION
Since `File.exists?` has been deprecated and removed in ruby 3.2.0, running scaffold command outputs this error message:

```
.../lib/datagrid/scaffold.rb:127:in 'file_exists?': undefined method `exists?' for File:Class (NoMethodError)

    File.exists?(name)
        ^^^^^^^^
Did you mean?  exist?
```