### PR TITLE
Fix minor sass spacing

### DIFF
--- a/app/assets/stylesheets/datagrid.sass
+++ b/app/assets/stylesheets/datagrid.sass
@@ -105,7 +105,7 @@ table.datagrid
 
 
 .datagrid-actions
-  padding-left: $dg-form-label +10
+  padding-left: $dg-form-label + 10
 
   input[type='submit']
     background-color: #555


### PR DESCRIPTION
This minor fix resolves a warning that happens when compling the sass with dartsass:

```
Deprecation Warning on line 108, column 18 of vendor/bundle/ruby/3.2.0/gems/datagrid-1.8.1/app/assets/stylesheets/datagrid.sass: 
This operation is parsed as:

    $dg-form-label + 10

but you may have intended it to mean:

    $dg-form-label (+10)

Add a space after + to clarify that it's meant to be a binary operation, or wrap
it in parentheses to make it a unary operation. This will be an error in future
versions of Sass.
```