### PR TITLE
Fix: Wrap Rails integrations into AS::Callback

### DIFF
--- a/lib/datagrid.rb
+++ b/lib/datagrid.rb
@@ -14,10 +14,14 @@ module Datagrid
   autoload :Configuration
 
   autoload :Helper
-  ActionView::Base.send(:include, Datagrid::Helper)
+  ::ActiveSupport.on_load(:action_view) do
+    ActionView::Base.send(:include, Datagrid::Helper)
+  end
 
   autoload :FormBuilder
-  ActionView::Helpers::FormBuilder.send(:include, Datagrid::FormBuilder)
+  ::ActiveSupport.on_load(:action_view) do
+    ActionView::Helpers::FormBuilder.send(:include, Datagrid::FormBuilder)
+  end
 
   autoload :Renderer
 


### PR DESCRIPTION
This fixes an issue, where Datagrid loads Rails' stuff during initialization, which is not optimal in some cases,

See:

https://github.com/rails/rails/issues/52740

In our case, the encryption config got loaded 'too late', because it was already loaded by several gems (such as Datagrid) before.