### PR TITLE
I18n namespace configuration per grid

### DIFF
--- a/lib/datagrid/core.rb
+++ b/lib/datagrid/core.rb
@@ -52,6 +52,7 @@ module Datagrid
         class_attribute :datagrid_attributes, instance_writer: false, default: []
         class_attribute :dynamic_block, instance_writer: false
         class_attribute :forbidden_attributes_protection, instance_writer: false, default: false
+        class_attribute :i18n_configuration, default: { namespace: nil, columns_namespace: nil, filters_namespace: nil }
       end
     end
 

--- a/lib/datagrid/utils.rb
+++ b/lib/datagrid/utils.rb
@@ -13,6 +13,15 @@ module Datagrid
 
       def translate_from_namespace(namespace, grid_class, key)
         lookups = []
+
+        if grid_class.i18n_configuration
+          specific_namespace = grid_class.i18n_configuration[:"#{namespace}_namespace"]
+          lookups << :"#{specific_namespace}.#{key}" if specific_namespace.present?
+
+          generic_namespace = grid_class.i18n_configuration[:namespace]
+          lookups << :"#{generic_namespace}.#{key}" if generic_namespace.present?
+        end
+
         namespaced_key = "#{namespace}.#{key}"
 
         grid_class.ancestors.each do |ancestor|

--- a/spec/datagrid/columns_spec.rb
+++ b/spec/datagrid/columns_spec.rb
@@ -98,6 +98,32 @@ describe Datagrid::Columns do
           expect(Report27.new.header.first).to eq("Nombre")
         end
       end
+
+      it "translates column-header using configured general namespace" do
+        grid = test_grid do
+          self.i18n_configuration = { namespace: "other.location" }
+
+          scope { Entry }
+          column(:name)
+        end
+
+        store_translations(:en, other: { location: { name: "Nosaukums" } }) do
+          expect(grid.header.first).to eq("Nosaukums")
+        end
+      end
+
+      it "prefers columns-specific translation namespace if configured" do
+        grid = test_grid do
+          self.i18n_configuration = { namespace: "other.general", columns_namespace: "other.columns" }
+
+          scope { Entry }
+          column(:name)
+        end
+
+        store_translations(:en, other: { general: { name: "Nosaukums" }, columns: { name: "Nosaukuma kolonna" } }) do
+          expect(grid.header.first).to eq("Nosaukuma kolonna")
+        end
+      end
     end
 
     it "returns html_columns" do

--- a/spec/datagrid/filters_spec.rb
+++ b/spec/datagrid/filters_spec.rb
@@ -202,6 +202,32 @@ describe Datagrid::Filters do
         expect(grid.filters.map(&:header)).to eq(["Navn"])
       end
     end
+
+    it "translates filter using configured general namespace" do
+      grid = test_grid do
+        self.i18n_configuration = { namespace: "other.location" }
+
+        scope { Entry }
+        filter(:name)
+      end
+
+      store_translations(:en, other: { location: { name: "Nosaukums" } }) do
+        expect(grid.filters.map(&:header)).to eq(["Nosaukums"])
+      end
+    end
+
+    it "prefers filters-specific translation namespace if configured" do
+      grid = test_grid do
+        self.i18n_configuration = { namespace: "other.general", filters_namespace: "other.filters" }
+
+        scope { Entry }
+        filter(:name)
+      end
+
+      store_translations(:en, other: { general: { name: "Nosaukums" }, filters: { name: "Nosaukuma filtrs" } }) do
+        expect(grid.filters.map(&:header)).to eq(["Nosaukuma filtrs"])
+      end
+    end
   end
 
   describe "#select_options" do


### PR DESCRIPTION
Introduces option to configure i18n namespaces per grid. 

Example use case - I want to re-use `activerecord.attributes.model` translation namespace for most of my backoffice app grids.

```
class ExampleGrid < ApplicationGrid
   self.i18n_configuration = {
     namespace: "...", # applicable to both column & filter headers
     columns_namespace: "...", # only for colums, preferred over `namespace` if defined
     filters_namespace: "...", # only for filters, preferred over `namespace` if defined
  }
end
```
