### PR TITLE
Expand default column / header options

### DIFF
--- a/lib/datagrid/columns.rb
+++ b/lib/datagrid/columns.rb
@@ -369,11 +369,9 @@ module Datagrid
           model.public_send(name)
         end
 
-        options_with_defaults = default_column_options.merge(options)
-
-        position = Datagrid::Utils.extract_position_from_options(columns, options_with_defaults)
+        position = Datagrid::Utils.extract_position_from_options(columns, options)
         column = Datagrid::Columns::Column.new(
-          self, name, query, options_with_defaults, &block
+          self, name, query, options, &block
         )
         columns.insert(position, column)
         column

--- a/lib/datagrid/columns.rb
+++ b/lib/datagrid/columns.rb
@@ -368,9 +368,12 @@ module Datagrid
         block ||= lambda do |model|
           model.public_send(name)
         end
-        position = Datagrid::Utils.extract_position_from_options(columns, options)
+
+        options_with_defaults = default_column_options.merge(options)
+
+        position = Datagrid::Utils.extract_position_from_options(columns, options_with_defaults)
         column = Datagrid::Columns::Column.new(
-          self, name, query, default_column_options.merge(options), &block
+          self, name, query, options_with_defaults, &block
         )
         columns.insert(position, column)
         column

--- a/lib/datagrid/columns.rb
+++ b/lib/datagrid/columns.rb
@@ -155,6 +155,10 @@ module Datagrid
   #
   #     self.default_column_options = { order: false }
   #
+  # It can also accept a proc with the column instance as an argument:
+  #
+  #     self.default_column_options = ->(column) { { order: column.name == :id } }
+  #
   # ## Columns Visibility
   #
   # Columns can be dynamically shown or hidden based on the grid's `column_names` accessor.
@@ -201,15 +205,19 @@ module Datagrid
   #     end
   module Columns
     # @!method default_column_options=(value)
-    #   @param [Hash] value default options passed to {#column} method call
-    #   @return [Hash] default options passed to {#column} method call
+    #   @param [Hash,Proc] value default options passed to {#column} method call.
+    #     When a proc is passed, it will be called with the column instance as an argument,
+    #     and expected to produce the options hash.
+    #   @return [Hash,Proc] default options passed to {#column} method call, or a proc that returns them.
     #   @example Disable default order
     #     self.default_column_options = { order: false }
     #   @example Makes entire report HTML
     #     self.default_column_options = { html: true }
+    #   @example Set the default header for all columns
+    #     self.default_column_options = ->(column) { { header: I18n.t(column.name, scope: 'my_scope.columns') } }
 
     # @!method default_column_options
-    #   @return [Hash] default options passed to {#column} method call
+    #   @return [Hash,Proc] default options passed to {#column} method call, or a proc that returns them.
     #   @see #default_column_options=
 
     # @!method batch_size=(value)

--- a/lib/datagrid/columns/column.rb
+++ b/lib/datagrid/columns/column.rb
@@ -86,7 +86,7 @@ module Datagrid
       # @return [String] column header
       def header
         if (header = options[:header])
-          Datagrid::Utils.callable(header)
+          Datagrid::Utils.callable(header, self)
         else
           Datagrid::Utils.translate_from_namespace(:columns, grid_class, name)
         end

--- a/lib/datagrid/columns/column.rb
+++ b/lib/datagrid/columns/column.rb
@@ -52,7 +52,7 @@ module Datagrid
         @grid_class = grid_class
         @name = name.to_sym
         @query = query
-        @options = options
+        @options = Datagrid::Utils.callable(grid_class.default_column_options, self).merge(options)
 
         if options[:class]
           Datagrid::Utils.warn_once(
@@ -86,7 +86,7 @@ module Datagrid
       # @return [String] column header
       def header
         if (header = options[:header])
-          Datagrid::Utils.callable(header, self)
+          Datagrid::Utils.callable(header)
         else
           Datagrid::Utils.translate_from_namespace(:columns, grid_class, name)
         end

--- a/lib/datagrid/core.rb
+++ b/lib/datagrid/core.rb
@@ -52,6 +52,7 @@ module Datagrid
         class_attribute :datagrid_attributes, instance_writer: false, default: []
         class_attribute :dynamic_block, instance_writer: false
         class_attribute :forbidden_attributes_protection, instance_writer: false, default: false
+        class_attribute :default_filter_options, default: {}
       end
     end
 

--- a/lib/datagrid/filters.rb
+++ b/lib/datagrid/filters.rb
@@ -163,6 +163,7 @@ module Datagrid
 
     included do
       include Datagrid::Core
+      class_attribute :default_filter_options, instance_writer: false, default: {}
       class_attribute :filters_array, default: []
     end
 
@@ -220,8 +221,10 @@ module Datagrid
         klass = type.is_a?(Class) ? type : FILTER_TYPES[type]
         raise ConfigurationError, "filter class #{type.inspect} not found" unless klass
 
-        position = Datagrid::Utils.extract_position_from_options(filters_array, options)
-        filter = klass.new(self, name, **options, &block)
+        options_with_defaults = default_filter_options.merge(options)
+
+        position = Datagrid::Utils.extract_position_from_options(filters_array, options_with_defaults)
+        filter = klass.new(self, name, **options_with_defaults, &block)
         filters_array.insert(position, filter)
 
         datagrid_attribute(name) do |value|

--- a/lib/datagrid/filters.rb
+++ b/lib/datagrid/filters.rb
@@ -221,10 +221,8 @@ module Datagrid
         klass = type.is_a?(Class) ? type : FILTER_TYPES[type]
         raise ConfigurationError, "filter class #{type.inspect} not found" unless klass
 
-        options_with_defaults = default_filter_options.merge(options)
-
-        position = Datagrid::Utils.extract_position_from_options(filters_array, options_with_defaults)
-        filter = klass.new(self, name, **options_with_defaults, &block)
+        position = Datagrid::Utils.extract_position_from_options(filters_array, options)
+        filter = klass.new(self, name, **options, &block)
         filters_array.insert(position, filter)
 
         datagrid_attribute(name) do |value|

--- a/lib/datagrid/filters.rb
+++ b/lib/datagrid/filters.rb
@@ -123,6 +123,16 @@ module Datagrid
   #     filter(:id, :integer, header: "Identifier")
   #     filter(:created_at, :date, range: true, default: proc { 1.month.ago.to_date..Date.today })
   #
+  # ## Default Filter Options
+  #
+  # Default options for all filters in a grid can be set using `default_filter_options`.
+  #
+  #     self.default_filter_options = { header: "" }
+  #
+  # It can also accept a proc with the filter instance as an argument:
+  #
+  #     self.default_filter_options = ->(filter) { { header: I18n.t(filter.name, scope: 'filters') } }
+  #
   # # Localization
   #
   # Filter labels can be localized or specified via the `:header` option:
@@ -130,6 +140,18 @@ module Datagrid
   #     filter(:created_at, :date, header: "Creation date")
   #     filter(:created_at, :date, header: proc { I18n.t("creation_date") })
   module Filters
+    # @!method default_filter_options=(value)
+    #   @param [Hash,Proc] value default options passed to {#filter} method call.
+    #     When a proc is passed, it will be called with the filter instance as an argument,
+    #     and expected to produce the options hash.
+    #   @return [Hash,Proc] default options passed to {#filter} method call, or a proc that returns them.
+    #   @example Set the default header for all filters
+    #     self.default_filter_options = ->(filter) { { header: I18n.t(filter.name, scope: 'my_scope.filters') } }
+
+    # @!method default_filter_options
+    #   @return [Hash,Proc] default options passed to {#filter} method call, or a proc that returns them.
+    #   @see #default_filter_options=
+
     require "datagrid/filters/base_filter"
     require "datagrid/filters/enum_filter"
     require "datagrid/filters/extended_boolean_filter"

--- a/lib/datagrid/filters/base_filter.rb
+++ b/lib/datagrid/filters/base_filter.rb
@@ -15,7 +15,7 @@ module Datagrid
       def initialize(grid_class, name, **options, &block)
         self.grid_class = grid_class
         self.name = name.to_sym
-        self.options = options
+        self.options = Datagrid::Utils.callable(grid_class.default_filter_options, self).merge(options)
         self.block = block
       end
 
@@ -76,7 +76,7 @@ module Datagrid
 
       def header
         if (header = options[:header])
-          Datagrid::Utils.callable(header, self)
+          Datagrid::Utils.callable(header)
         else
           Datagrid::Utils.translate_from_namespace(:filters, grid_class, name)
         end

--- a/lib/datagrid/filters/base_filter.rb
+++ b/lib/datagrid/filters/base_filter.rb
@@ -76,7 +76,7 @@ module Datagrid
 
       def header
         if (header = options[:header])
-          Datagrid::Utils.callable(header)
+          Datagrid::Utils.callable(header, self)
         else
           Datagrid::Utils.translate_from_namespace(:filters, grid_class, name)
         end

--- a/lib/datagrid/utils.rb
+++ b/lib/datagrid/utils.rb
@@ -133,8 +133,8 @@ module Datagrid
           !property_availability(grid, unless_option, false)
       end
 
-      def callable(value)
-        value.respond_to?(:call) ? value.call : value
+      def callable(value, *arguments)
+        value.respond_to?(:call) ? value.call(*arguments) : value
       end
 
       protected

--- a/spec/datagrid/columns_spec.rb
+++ b/spec/datagrid/columns_spec.rb
@@ -98,6 +98,30 @@ describe Datagrid::Columns do
           expect(Report27.new.header.first).to eq("Nombre")
         end
       end
+
+      it "uses configured default header" do
+        grid = test_grid do
+          self.default_column_options = { header: ->(column) { I18n.t(column.name, scope: "other.location") } }
+
+          scope { Entry }
+          column(:name)
+        end
+
+        store_translations(:en, other: { location: { name: "Nosaukums" } }) do
+          expect(grid.header.first).to eq("Nosaukums")
+        end
+      end
+
+      it "prefers column-specific header over default" do
+        grid = test_grid do
+          self.default_column_options = { header: -> { "Global Header" } }
+
+          scope { Entry }
+          column(:name, header: "Column Specific Header")
+        end
+
+        expect(grid.header.first).to eq("Column Specific Header")
+      end
     end
 
     it "returns html_columns" do

--- a/spec/datagrid/columns_spec.rb
+++ b/spec/datagrid/columns_spec.rb
@@ -335,6 +335,23 @@ describe Datagrid::Columns do
       report.attributes = { order: :name, descending: true }
       expect(report.assets).to eq([second, first])
     end
+
+    it "accepts proc as default column options" do
+      report = test_grid do
+        scope { Entry }
+        self.default_column_options = ->(column) { { order: column.name == :name ? "name" : false } }
+        column(:id)
+        column(:name)
+      end
+      first = Entry.create(name: "1st")
+      second = Entry.create(name: "2nd")
+      expect do
+        report.attributes = { order: :id }
+        report.assets
+      end.to raise_error(Datagrid::OrderUnsupported)
+      report.attributes = { order: :name, descending: true }
+      expect(report.assets).to eq([second, first])
+    end
   end
 
   describe "fetching data in batches" do

--- a/spec/datagrid/columns_spec.rb
+++ b/spec/datagrid/columns_spec.rb
@@ -101,7 +101,7 @@ describe Datagrid::Columns do
 
       it "uses configured default header" do
         grid = test_grid do
-          self.default_column_options = { header: ->(column) { I18n.t(column.name, scope: "other.location") } }
+          self.default_column_options = ->(column) { { header: -> { I18n.t(column.name, scope: "other.location") } } }
 
           scope { Entry }
           column(:name)

--- a/spec/datagrid/filters_spec.rb
+++ b/spec/datagrid/filters_spec.rb
@@ -328,4 +328,30 @@ describe Datagrid::Filters do
       end
     end
   end
+
+  describe ".default_filter_options" do
+    it "passes default options to each filter definition" do
+      grid = test_grid do
+        scope { Entry }
+        self.default_filter_options = { header: "Guess!" }
+        filter(:id, :integer)
+        filter(:name, :string)
+      end
+
+      expect(grid.filters.map(&:header)).to eq(["Guess!", "Guess!"])
+    end
+
+    it "accepts proc as default filter options" do
+      grid = test_grid do
+        scope { Entry }
+        self.default_filter_options = lambda { |filter|
+          { header: filter.name == :id ? "Identification!" : filter.name.to_s }
+        }
+        filter(:id, :integer)
+        filter(:name, :string)
+      end
+
+      expect(grid.filters.map(&:header)).to eq(["Identification!", "name"])
+    end
+  end
 end

--- a/spec/datagrid/filters_spec.rb
+++ b/spec/datagrid/filters_spec.rb
@@ -202,6 +202,30 @@ describe Datagrid::Filters do
         expect(grid.filters.map(&:header)).to eq(["Navn"])
       end
     end
+
+    it "translates filter using configured default header" do
+      grid = test_grid do
+        self.default_filter_options = { header: ->(filter) { I18n.t(filter.name, scope: "other.location") } }
+
+        scope { Entry }
+        filter(:name)
+      end
+
+      store_translations(:en, other: { location: { name: "Nosaukums" } }) do
+        expect(grid.filters.map(&:header)).to eq(["Nosaukums"])
+      end
+    end
+
+    it "prefers filter-specific header over default" do
+      grid = test_grid do
+        self.default_filter_options = { header: -> { "Global Header" } }
+
+        scope { Entry }
+        filter(:name, header: "Filter Specific Header")
+      end
+
+      expect(grid.filters.map(&:header)).to eq(["Filter Specific Header"])
+    end
   end
 
   describe "#select_options" do

--- a/spec/datagrid/filters_spec.rb
+++ b/spec/datagrid/filters_spec.rb
@@ -205,7 +205,7 @@ describe Datagrid::Filters do
 
     it "translates filter using configured default header" do
       grid = test_grid do
-        self.default_filter_options = { header: ->(filter) { I18n.t(filter.name, scope: "other.location") } }
+        self.default_filter_options = ->(filter) { { header: -> { I18n.t(filter.name, scope: "other.location") } } }
 
         scope { Entry }
         filter(:name)


### PR DESCRIPTION
Based on feedback in https://github.com/bogdan/datagrid/pull/332

* Expand default column options to allow setting a global header naming scheme
* Add default filter options