### PR TITLE
Fix README.md typo in view generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ insert  app/assets/stylesheet/application.css
 In order to get a control on datagrid built-in views run:
 
 ``` sh
-rails g datagrid::views
+rails g datagrid:views
 ```
 
 #### Advanced frontend


### PR DESCRIPTION
Found a typo in this section => https://github.com/bogdan/datagrid?tab=readme-ov-file#customize-built-in-views