### PR TITLE
Fix inheriting default column options

### DIFF
--- a/lib/datagrid/columns/column.rb
+++ b/lib/datagrid/columns/column.rb
@@ -43,16 +43,16 @@ module Datagrid
       #   @return [Class] grid class where column is defined
       # @attribute [r] name
       #   @return [Symbol] column name
-      # @attribute [r] options
+      # @attribute [r] column_options
       #   @return [Hash<Symbol, Object>] column options
       attr_reader :grid_class, :name, :query, :options, :data_block, :html_block
 
       # @!visibility private
-      def initialize(grid_class, name, query, options = {}, &block)
+      def initialize(grid_class, name, query, column_options = {}, &block)
         @grid_class = grid_class
         @name = name.to_sym
         @query = query
-        @options = Datagrid::Utils.callable(grid_class.default_column_options, self).merge(options)
+        @options = Datagrid::Utils.callable(grid_class.default_column_options, self).merge(column_options)
 
         if options[:class]
           Datagrid::Utils.warn_once(

--- a/spec/datagrid/columns/column_spec.rb
+++ b/spec/datagrid/columns/column_spec.rb
@@ -16,4 +16,18 @@ describe Datagrid::Columns::Column do
       expect(subject.inspect).to eq('#<Datagrid::Columns::Column ColumnInspectTest#id {:header=>"ID"}>')
     end
   end
+
+  describe 'initialize' do
+    subject do
+      class DefaultOptionsGrid < Datagrid::Base
+        self.default_column_options = { html: true }
+      end
+
+      Datagrid::Columns::Column.new(DefaultOptionsGrid, :id, "id", {})
+    end
+
+    it 'correctly inherits default options' do
+      expect(subject.options).to match(html: true)
+    end
+  end
 end


### PR DESCRIPTION
This fixes a regression caused by #333 in https://github.com/bogdan/datagrid/pull/333/files#diff-e862b050fb30334bd970ac6714786a6120a21c965b4a95f3f57b3f4792adafaeR382.

Merging the default options was moved into the initializer, but  it still used the raw argument `options` instead of `@options`. Ruby chose the locally scoped `options` from arguments instead of the attribute reader.

Solved by renaming the argument to avoid ambiguity